### PR TITLE
First cut of the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Then alter your homeserver configuration, adding to your `modules` configuration
 modules:
   - module: synapse_bind_sydent.SydentBinder
     config:
-      # TODO: Complete this section with an example for your module
+      # The hostname (or IP address) of the Sydent instance to bind to. Must be reachable
+      # by Synapse.
+      # Required.
+      sydent_host: example.com
+      # Whether to use HTTPS when sending a request to Sydent.
+      # Optional, defaults to false.
+      use_https: false
 ```
 
 
@@ -73,14 +79,4 @@ Synapse developers (assuming a Unix-like shell):
  6. Push the tag.
     ```shell
     git push origin tag v$version
-    ```
-
- 7. If applicable:
-    Create a *release*, based on the tag you just pushed, on GitHub or GitLab.
-
- 8. If applicable:
-    Create a source distribution and upload it to PyPI:
-    ```shell
-    python -m build
-    twine upload dist/synapse_bind_sydent-$version*
     ```

--- a/README.md
+++ b/README.md
@@ -17,13 +17,10 @@ Then alter your homeserver configuration, adding to your `modules` configuration
 modules:
   - module: synapse_bind_sydent.SydentBinder
     config:
-      # The hostname (or IP address) of the Sydent instance to bind to. Must be reachable
-      # by Synapse.
+      # The base URL (protocol + hostname or address) of the Sydent instance to bind to.
+      # Must be reachable by Synapse.
       # Required.
-      sydent_host: example.com
-      # Whether to use HTTPS when sending a request to Sydent.
-      # Optional, defaults to false.
-      use_https: false
+      sydent_base_url: https://example.com
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bind 3PIDs to Sydent
 
-A module that leverages Sydent's internal bind APIs to automatically record 3PIDs association on an IS upon registration.
+A module that leverages Sydent's internal bind APIs to automatically record 3PIDs
+association on a Sydent instance once it's been verified on the local Synapse homeserver.
 
 
 ## Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ dev =
   # for type checking
   mypy == 0.910
   # for linting
-  black == 21.9b0
+  black == 22.3.0
   flake8 == 4.0.1
   isort == 5.9.3
 

--- a/synapse_bind_sydent/__init__.py
+++ b/synapse_bind_sydent/__init__.py
@@ -40,6 +40,10 @@ class SydentBinder:
             f"{protocol}://{config.sydent_host}/_matrix/identity/internal/bind"
         )
 
+        self._api.register_account_validity_callbacks(
+            on_user_registration=self.on_register,
+        )
+
     @staticmethod
     def parse_config(config: Dict[str, Any]) -> SydentBinderConfig:
         if "sydent_host" not in config or not isinstance(config["sydent_host"], str):

--- a/synapse_bind_sydent/__init__.py
+++ b/synapse_bind_sydent/__init__.py
@@ -1,0 +1,81 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Any, Dict
+
+import attr
+from synapse.module_api import ModuleApi
+from synapse.module_api.errors import ConfigError
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class SydentBinderConfig:
+    sydent_host: str
+    use_https: bool = False
+
+
+class SydentBinder:
+    def __init__(self, config: SydentBinderConfig, api: ModuleApi) -> None:
+        # Keep a reference to the config and Module API
+        self._api = api
+        self._config = config
+
+        self._http_client = api.http_client
+
+        protocol = "https" if config.use_https else "http"
+        self._sydent_bind_url = (
+            f"{protocol}://{config.sydent_host}/_matrix/identity/internal/bind"
+        )
+
+    @staticmethod
+    def parse_config(config: Dict[str, Any]) -> SydentBinderConfig:
+        if "sydent_host" not in config or not isinstance(config["sydent_host"], str):
+            raise ConfigError("sydent_host needs to be a string")
+
+        return SydentBinderConfig(**config)
+
+    async def on_register(self, user_id: str) -> None:
+        """Binds the 3PID on registration."""
+        # Get the list of 3PIDs for this user.
+        threepids = await self._api.get_threepids_for_user(user_id)
+
+        for threepid in threepids:
+            body = {
+                "address": threepid["address"],
+                "medium": threepid["medium"],
+                "mxid": user_id,
+            }
+
+            # Bind the threepid
+            try:
+                await self._http_client.post_json_get_json(self._sydent_bind_url, body)
+            except Exception as e:
+                # If there was an error, the IS is likely unreachable, so don't try again.
+                logger.exception(
+                    "Failed to bind 3PID %s to identity server at %s: %s",
+                    threepid,
+                    self._sydent_bind_url,
+                    e,
+                )
+                return
+
+            # Store the association, so we can use this to unbind later.
+            await self._api.store_remote_3pid_association(
+                user_id,
+                threepid["medium"],
+                threepid["address"],
+                self._config.sydent_host,
+            )

--- a/synapse_bind_sydent/__init__.py
+++ b/synapse_bind_sydent/__init__.py
@@ -39,8 +39,7 @@ class SydentBinder:
             f"{config.sydent_base_url}/_matrix/identity/internal/bind"
         )
 
-        scheme = urlparse(config.sydent_base_url).scheme
-        self._sydent_host = config.sydent_base_url.replace(f"{scheme}://", "")
+        self._sydent_host = urlparse(config.sydent_base_url).netloc
 
         self._api.register_third_party_rules_callbacks(
             on_threepid_bind=self.on_threepid_bind,
@@ -53,9 +52,7 @@ class SydentBinder:
         ):
             raise ConfigError("sydent_base_url needs to be a string")
 
-        if not config["sydent_base_url"].startswith("http://") and not config[
-            "sydent_base_url"
-        ].startswith("https://"):
+        if urlparse(config["sydent_base_url"]).scheme not in ("http", "https"):
             raise ConfigError(
                 "sydent_base_url needs to include an HTTP(S) protocol scheme"
             )

--- a/synapse_bind_sydent/__init__.py
+++ b/synapse_bind_sydent/__init__.py
@@ -48,16 +48,14 @@ class SydentBinder:
 
     @staticmethod
     def parse_config(config: Dict[str, Any]) -> SydentBinderConfig:
-        if (
-            "sydent_base_url" not in config
-            or not isinstance(config["sydent_base_url"], str)
+        if "sydent_base_url" not in config or not isinstance(
+            config["sydent_base_url"], str
         ):
             raise ConfigError("sydent_base_url needs to be a string")
 
-        if (
-            not config["sydent_base_url"].startswith("http://")
-            and not config["sydent_base_url"].startswith("https://")
-        ):
+        if not config["sydent_base_url"].startswith("http://") and not config[
+            "sydent_base_url"
+        ].startswith("https://"):
             raise ConfigError(
                 "sydent_base_url needs to include an HTTP(S) protocol scheme"
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,15 +19,10 @@ def make_awaitable(result: TV) -> Awaitable[TV]:
     return future
 
 
-def create_module(
-    user_threepids: List[Dict[str, Any]], http_mock: Mock
-) -> SydentBinder:
+def create_module(http_mock: Mock) -> SydentBinder:
     # Create a mock based on the ModuleApi spec, but override some mocked functions
     # because some capabilities are needed for running the tests.
     module_api = Mock(spec=ModuleApi)
-    module_api.get_threepids_for_user = Mock(
-        return_value=make_awaitable(user_threepids)
-    )
     module_api.store_remote_3pid_association = Mock(return_value=make_awaitable(None))
     module_api.http_client = http_mock
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,37 @@
+from asyncio import Future
+from typing import Any, Awaitable, Dict, List, TypeVar
+
+from mock import Mock
+from synapse.module_api import ModuleApi
+
+from synapse_bind_sydent import SydentBinder
+
+TV = TypeVar("TV")
+
+
+def make_awaitable(result: TV) -> Awaitable[TV]:
+    """
+    Makes an awaitable, suitable for mocking an `async` function.
+    This function is copied from Synapse's test code.
+    """
+    future = Future()  # type: ignore
+    future.set_result(result)
+    return future
+
+
+def create_module(
+    user_threepids: List[Dict[str, Any]], http_mock: Mock
+) -> SydentBinder:
+    # Create a mock based on the ModuleApi spec, but override some mocked functions
+    # because some capabilities are needed for running the tests.
+    module_api = Mock(spec=ModuleApi)
+    module_api.get_threepids_for_user = Mock(
+        return_value=make_awaitable(user_threepids)
+    )
+    module_api.store_remote_3pid_association = Mock(return_value=make_awaitable(None))
+    module_api.http_client = http_mock
+
+    # If necessary, give parse_config some configuration to parse.
+    config = SydentBinder.parse_config({"sydent_host": "test"})
+
+    return SydentBinder(config, module_api)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 from asyncio import Future
-from typing import Awaitable, TypeVar
+from typing import Awaitable, Dict, Optional, TypeVar
 from unittest.mock import Mock
 
 from synapse.module_api import ModuleApi
@@ -19,7 +19,9 @@ def make_awaitable(result: TV) -> Awaitable[TV]:
     return future
 
 
-def create_module(http_mock: Mock, config_override={}) -> SydentBinder:
+def create_module(
+    http_mock: Mock, config_override: Optional[Dict[str, str]] = None
+) -> SydentBinder:
     # Create a mock based on the ModuleApi spec, but override some mocked functions
     # because some capabilities are needed for running the tests.
     module_api = Mock(spec=ModuleApi)
@@ -27,6 +29,9 @@ def create_module(http_mock: Mock, config_override={}) -> SydentBinder:
     module_api.http_client = http_mock
 
     # If necessary, give parse_config some configuration to parse.
+    if config_override is None:
+        config_override = {}
+
     config_override.setdefault("sydent_base_url", "https://test")
     config = SydentBinder.parse_config(config_override)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,7 +19,7 @@ def make_awaitable(result: TV) -> Awaitable[TV]:
     return future
 
 
-def create_module(http_mock: Mock) -> SydentBinder:
+def create_module(http_mock: Mock, config_override={}) -> SydentBinder:
     # Create a mock based on the ModuleApi spec, but override some mocked functions
     # because some capabilities are needed for running the tests.
     module_api = Mock(spec=ModuleApi)
@@ -27,6 +27,7 @@ def create_module(http_mock: Mock) -> SydentBinder:
     module_api.http_client = http_mock
 
     # If necessary, give parse_config some configuration to parse.
-    config = SydentBinder.parse_config({"sydent_host": "test"})
+    config_override.setdefault("sydent_base_url", "https://test")
+    config = SydentBinder.parse_config(config_override)
 
     return SydentBinder(config, module_api)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 from asyncio import Future
 from typing import Any, Awaitable, Dict, List, TypeVar
 
-from mock import Mock
+from unittest.mock import Mock
 from synapse.module_api import ModuleApi
 
 from synapse_bind_sydent import SydentBinder

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 from asyncio import Future
-from typing import Any, Awaitable, Dict, List, TypeVar
+from typing import Awaitable, TypeVar
 from unittest.mock import Mock
 
 from synapse.module_api import ModuleApi

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 from asyncio import Future
 from typing import Any, Awaitable, Dict, List, TypeVar
-
 from unittest.mock import Mock
+
 from synapse.module_api import ModuleApi
 
 from synapse_bind_sydent import SydentBinder

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import aiounittest
+from synapse.module_api.errors import ConfigError
 
 from tests import create_module, make_awaitable
 
@@ -64,3 +65,13 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
 
         store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
         self.assertEqual(store_remote_3pid_association.call_count, 0)
+
+    async def test_base_url_missing_scheme(self):
+        """Tests that trying to initialise the module with a base URL that doesn't include
+        a URL scheme raises an exception.
+        """
+        with self.assertRaises(ConfigError):
+            create_module(
+                http_mock=Mock(),
+                config_override={"sydent_base_url": "test"},
+            )

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -66,7 +66,7 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
         store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
         self.assertEqual(store_remote_3pid_association.call_count, 0)
 
-    async def test_base_url_missing_scheme(self):
+    async def test_base_url_missing_scheme(self) -> None:
         """Tests that trying to initialise the module with a base URL that doesn't include
         a URL scheme raises an exception.
         """

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -20,26 +20,7 @@ from tests import create_module, make_awaitable
 
 
 class SydentBinderTestCase(aiounittest.AsyncTestCase):
-    async def test_no_assoc(self) -> None:
-        """Tests that the right function calls are made when the newly registered user has
-        no 3PID associated.
-        """
-        http_client = Mock()
-        http_client.post_json_get_json = Mock(return_value=make_awaitable(None))
-
-        module = create_module(
-            user_threepids=[],
-            http_mock=http_client,
-        )
-
-        await module.on_register("@jdoe:matrix.org")
-
-        self.assertEqual(http_client.post_json_get_json.call_count, 0)
-
-        store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
-        self.assertEqual(store_remote_3pid_association.call_count, 0)
-
-    async def test_single_assoc(self) -> None:
+    async def test_new_assoc(self) -> None:
         """Tests that the right function calls are made when the newly registered user has
         a single 3PID associated.
         """
@@ -50,17 +31,9 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
         medium = "email"
         user_id = "@jdoe:example.com"
 
-        module = create_module(
-            user_threepids=[
-                {
-                    "medium": medium,
-                    "address": address,
-                }
-            ],
-            http_mock=http_client,
-        )
+        module = create_module(http_mock=http_client)
 
-        await module.on_register(user_id)
+        await module.on_threepid_bind(user_id, medium, address)
 
         self.assertEqual(http_client.post_json_get_json.call_count, 1)
         args = http_client.post_json_get_json.call_args[0]
@@ -73,42 +46,6 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
         args = store_remote_3pid_association.call_args[0]
         self.assertEqual(args, (user_id, medium, address, "test"))
 
-    async def test_multiple_assoc(self) -> None:
-        """Tests that the right function calls are made when the newly registered user has
-        multiple 3PIDs associated.
-        """
-        http_client = Mock()
-        http_client.post_json_get_json = Mock(return_value=make_awaitable(None))
-
-        assocs = [
-            {"medium": "email", "address": "jdoe@example.com"},
-            {"medium": "email", "address": "jdoe1@example.com"},
-            {"medium": "msisdn", "address": "0000000"},
-        ]
-        user_id = "@jdoe:matrix.org"
-
-        module = create_module(user_threepids=assocs, http_mock=http_client)
-
-        await module.on_register(user_id)
-
-        self.assertEqual(http_client.post_json_get_json.call_count, len(assocs))
-        args = http_client.post_json_get_json.call_args[0]
-        self.assertEqual(
-            args[1],
-            {
-                "address": assocs[-1]["address"],
-                "medium": assocs[-1]["medium"],
-                "mxid": user_id,
-            },
-        )
-
-        store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
-        self.assertEqual(store_remote_3pid_association.call_count, len(assocs))
-        args = store_remote_3pid_association.call_args[0]
-        self.assertEqual(
-            args, (user_id, assocs[-1]["medium"], assocs[-1]["address"], "test")
-        )
-
     async def test_network_error(self) -> None:
         """Tests that the process is aborted right away if an error was raised when trying
         to bind a 3PID."""
@@ -119,15 +56,9 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
         http_client = Mock()
         http_client.post_json_get_json = Mock(side_effect=post_json_get_json)
 
-        assocs = [
-            {"medium": "email", "address": "jdoe@example.com"},
-            {"medium": "email", "address": "jdoe1@example.com"},
-            {"medium": "msisdn", "address": "0000000"},
-        ]
+        module = create_module(http_mock=http_client)
 
-        module = create_module(user_threepids=assocs, http_mock=http_client)
-
-        await module.on_register("@jdoe:matrix.org")
+        await module.on_threepid_bind("@jdoe:matrix.org", "email", "jdoe@example.com")
 
         self.assertEqual(http_client.post_json_get_json.call_count, 1)
 

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -1,0 +1,135 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+from unittest.mock import Mock
+
+import aiounittest
+
+from tests import create_module, make_awaitable
+
+
+class SydentBinderTestCase(aiounittest.AsyncTestCase):
+    async def test_no_assoc(self) -> None:
+        """Tests that the right function calls are made when the newly registered user has
+        no 3PID associated.
+        """
+        http_client = Mock()
+        http_client.post_json_get_json = Mock(return_value=make_awaitable(None))
+
+        module = create_module(
+            user_threepids=[],
+            http_mock=http_client,
+        )
+
+        await module.on_register("@jdoe:matrix.org")
+
+        self.assertEqual(http_client.post_json_get_json.call_count, 0)
+
+        store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
+        self.assertEqual(store_remote_3pid_association.call_count, 0)
+
+
+    async def test_single_assoc(self) -> None:
+        """Tests that the right function calls are made when the newly registered user has
+        a single 3PID associated.
+        """
+        http_client = Mock()
+        http_client.post_json_get_json = Mock(return_value=make_awaitable(None))
+
+        address = "jdoe@example.com"
+        medium = "email"
+        user_id = "@jdoe:example.com"
+
+        module = create_module(
+            user_threepids=[
+                {
+                    "medium": medium,
+                    "address": address,
+                }
+            ],
+            http_mock=http_client,
+        )
+
+        await module.on_register(user_id)
+
+        self.assertEqual(http_client.post_json_get_json.call_count, 1)
+        args = http_client.post_json_get_json.call_args[0]
+        self.assertEqual(
+            args[1], {"address": address, "medium": medium, "mxid": user_id}
+        )
+
+        store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
+        self.assertEqual(store_remote_3pid_association.call_count, 1)
+        args = store_remote_3pid_association.call_args[0]
+        self.assertEqual(args, (user_id, medium, address, "test"))
+
+    async def test_multiple_assoc(self) -> None:
+        """Tests that the right function calls are made when the newly registered user has
+        multiple 3PIDs associated.
+        """
+        http_client = Mock()
+        http_client.post_json_get_json = Mock(return_value=make_awaitable(None))
+
+        assocs = [
+            {"medium": "email", "address": "jdoe@example.com"},
+            {"medium": "email", "address": "jdoe1@example.com"},
+            {"medium": "msisdn", "address": "0000000"},
+        ]
+        user_id = "@jdoe:matrix.org"
+
+        module = create_module(user_threepids=assocs, http_mock=http_client)
+
+        await module.on_register(user_id)
+
+        self.assertEqual(http_client.post_json_get_json.call_count, len(assocs))
+        args = http_client.post_json_get_json.call_args[0]
+        self.assertEqual(
+            args[1],
+            {
+                "address": assocs[-1]["address"],
+                "medium": assocs[-1]["medium"],
+                "mxid": user_id,
+            },
+        )
+
+        store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
+        self.assertEqual(store_remote_3pid_association.call_count, len(assocs))
+        args = store_remote_3pid_association.call_args[0]
+        self.assertEqual(
+            args, (user_id, assocs[-1]["medium"], assocs[-1]["address"], "test")
+        )
+
+    async def test_network_error(self) -> None:
+        """Tests that the process is aborted right away if an error was raised when trying
+        to bind a 3PID."""
+        async def post_json_get_json(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("oh no")
+
+        http_client = Mock()
+        http_client.post_json_get_json = Mock(side_effect=post_json_get_json)
+
+        assocs = [
+            {"medium": "email", "address": "jdoe@example.com"},
+            {"medium": "email", "address": "jdoe1@example.com"},
+            {"medium": "msisdn", "address": "0000000"},
+        ]
+
+        module = create_module(user_threepids=assocs, http_mock=http_client)
+
+        await module.on_register("@jdoe:matrix.org")
+
+        self.assertEqual(http_client.post_json_get_json.call_count, 1)
+
+        store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
+        self.assertEqual(store_remote_3pid_association.call_count, 0)

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -39,7 +39,6 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
         store_remote_3pid_association: Mock = module._api.store_remote_3pid_association  # type: ignore[assignment]
         self.assertEqual(store_remote_3pid_association.call_count, 0)
 
-
     async def test_single_assoc(self) -> None:
         """Tests that the right function calls are made when the newly registered user has
         a single 3PID associated.
@@ -113,6 +112,7 @@ class SydentBinderTestCase(aiounittest.AsyncTestCase):
     async def test_network_error(self) -> None:
         """Tests that the process is aborted right away if an error was raised when trying
         to bind a 3PID."""
+
         async def post_json_get_json(*args: Any, **kwargs: Any) -> None:
             raise RuntimeError("oh no")
 


### PR DESCRIPTION
This work is happening in the context of the Tchap mainlining. In Tchap, when a user is registered (which always requires an email to be set), the email is automatically bound to a Sydent instance using the internal API (so that their email can be looked up immediately, and without having to go through additional manual validation).

This module implements this behaviour by using the `on_user_registration` account validity callback, as well as a module API method added in https://github.com/matrix-org/synapse/pull/12195.

The CI is expecting to fail since https://github.com/matrix-org/synapse/pull/12195 hasn't made it into mainline CI yet, but it's all passing locally.