### PR TITLE
Add quotes around requires statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ modules:
 
 In a virtual environment with pip ≥ 21.1, run
 ```shell
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 To run the unit tests, you can either use:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A module that leverages Sydent's internal bind APIs to automatically record 3PIDs
 association on a Sydent instance once it's been verified on the local Synapse homeserver.
 
+This module works with Synapse v1.78.0 and above.
 
 ## Installation
 


### PR DESCRIPTION
Otherwise the command fails on zsh with "no matches found".