### PR TITLE
Add GitHub release creation instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,5 @@ Synapse developers (assuming a Unix-like shell):
     ```shell
     git push origin tag v$version
     ```
+
+ 7. [Create a *GitHub release*](https://github.com/matrix-org/synapse-bind-sydent/releases/new), based on the tag you just pushed. 


### PR DESCRIPTION
This aligns the release instructions in this module with those in the Synapse module cookiecutter template that are relevant to this module: https://github.com/matrix-org/synapse-module-cookiecutter-template/tree/main/%7B%7B%20cookiecutter.directory_name%20%7D%7D#releasing

This module should gain a GitHub release each time a new version is cut. However, we (currently) do not publish this module to PyPI.